### PR TITLE
feat: Usability tweaks (thread id, timestamp source) etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ fn useLoggerPool(pool: *LoggerPool) void {
 
 ```
 
-A few silly examples:
+A few trivial examples:
 
 ```zig
 
@@ -173,7 +173,33 @@ for (0..5) |idx| {
 
 ```
 
-### Using the global logger pool
+### The source of timestamps may be overridden
+
+`LogOptions.ns_ts_supplier` defaults to the system's nanosecond-precision timestamp supplier.
+If running a simulator with accellerated time, for example, you can provide your own, e.g.
+
+Given a `simulator` package with a function having the signature:
+```zig
+pub fn virtualNanosSinceEpoch() i128
+```
+
+We can use the simulator's virtual timestamps as follows:
+
+```zig
+
+    const sim = @import("simulator");
+
+    var log_options: LogOptions = .{
+        // other overrides
+        // ...
+        // now provide our timestamp supplier
+        .ns_ts_supplier = sim.virtualNanosSinceEpoch,
+    };
+
+```
+
+
+### Using the global logger pool (optional)
 
 In your main module, initialize the global logger pool, e.g.
 
@@ -205,7 +231,7 @@ pub fn main() !void {
 
 ### ULIDs
 
-I added `ULID` support for immediate needs, but it may be useful nonetheless.
+I added [ULID](https://github.com/ulid/spec) support for logging needs, but it may be useful by itself.
 
 - `Ulid` struct and `Generator`.
     - The `Ulid` struct is packed such that it is trivially bit-castable to `u128` or `[16]u8`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hissylogz (Module `hissylogz`)
+# hissylogz
 
 Structured logging support for Zig, enjoy, or my cat may hiss at you.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ Structured logging support for Zig, enjoy, or my cat may hiss at you.
 
 I created a miniature logging framework to satisfy my immediate needs:
 - Simple, low ceremony logging
-- Out-of-the-box log output friendly to cloud deployments (EKS, LOKI, etc) and log scrapers
 - Thread-safe, yet performant with efficient resource usage
+- Out-of-the-box log output friendly to cloud deployments (EKS, LOKI, etc) and log scrapers
+- [ULID](https://github.com/ulid/spec) (Universally Unique Lexicographically Sortable Identifiers) support
+    - `Ulid` type
+    - `Ulid` generator
 
 Non-goals:
 - Do everything (loading config from various sources, have rolling file appenders, etc)
@@ -21,7 +24,7 @@ These are early days, and the feature set may grow, bugs will be found and fixed
 Let zig fetch the package and integrate it into your `build.zig.zon` automagically:
 
 ```shell
-zig fetch --save https://github.com/hissyfit-dev/hissylogz/archive/refs/tags/v0.0.9.tar.gz
+zig fetch --save https://github.com/hissyfit-dev/hissylogz/archive/refs/tags/v0.0.10.tar.gz
 ```
 
 ### Integrate into your build
@@ -200,6 +203,39 @@ pub fn main() !void {
 }
 ```
 
+### ULIDs
+
+I added `ULID` support for immediate needs, but it may be useful nonetheless.
+
+- `Ulid` struct and `Generator`.
+    - The `Ulid` struct is packed such that it is trivially bit-castable to `u128` or `[16]u8`.
+    - Maintains monotonic sort order (correctly detects and handles the same millisecond) per `generator`.
+
+> For all-singing, all-dancing ULID support, consider [ulid-zig](https://github.com/rsepassi/ulid-zig).
+
+
+```zig
+
+const hissylogz = @import("hissylogz");
+const ulid = hissylogz.ulid;
+
+pub fn main() !void {
+
+    var gen = ulid.generator();
+
+    const ulid_0 = try gen.next();
+    const ulid_1 = try gen.next();
+
+    const str = ulid_0.encode();
+    const ulid_from_str = try ulid.decode(&str);
+
+    const bytes = ulid_0.bytes();
+    const ulid_from_bytes = try ulid.fromBytes(&bytes);
+
+}
+
+```
+
 
 ## Dependencies
 
@@ -212,6 +248,10 @@ This module uses [`datetime`](https://github.com/clickingbuttons/datetime) for t
 ## Acknowledgements
 
 I drew inspiration for the logger/entry API from [`log.zig`](https://github.com/karlseguin/log.zig).
+
+I re-purposed bits lifted from [ulid-zig](https://github.com/rsepassi/ulid-zig) under 0BSD.
+This is a solid library and comes with plenty of bells and whistles, a nice C ABI, the works.
+I've added known error sets, and a heavily trimmed down, restructured API.
 
 ## License
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "hissylogz",
-    .version = "0.0.9",
+    .version = "0.0.10",
     .paths = .{ "src", "build.zig", "build.zig.zon", "README.md", "LICENSE.md", "doc" },
     .dependencies = .{
         .datetime = .{

--- a/src/JsonAppender.zig
+++ b/src/JsonAppender.zig
@@ -15,8 +15,8 @@ pub const errors = @import("errors.zig");
 pub const AccessError = errors.AccessError;
 pub const AllocationError = errors.AllocationError;
 pub const LogBuffer = @import("LogBuffer.zig");
-pub const Timestamp = constants.Timestamp;
 pub const LogLevel = constants.LogLevel;
+pub const LogTime = @import("LogTime.zig");
 pub const Ulid = @import("ulid.zig").Ulid;
 
 const Self = @This();
@@ -32,9 +32,9 @@ output: Output,
 output_mutex: *std.Thread.Mutex,
 log_buffer: LogBuffer,
 level: LogLevel,
-timestamp: Timestamp,
+timestamp: LogTime,
 
-pub fn init(allocator: std.mem.Allocator, output: Output, output_mutex: *std.Thread.Mutex, level: LogLevel, timestamp: Timestamp) AllocationError!Self {
+pub fn init(allocator: std.mem.Allocator, output: Output, output_mutex: *std.Thread.Mutex, level: LogLevel, timestamp: LogTime) AllocationError!Self {
     var new_log_buffer = try LogBuffer.init(allocator);
     errdefer new_log_buffer.deinit();
 
@@ -53,7 +53,7 @@ pub fn deinit(self: *Self) void {
 }
 
 pub fn reset(self: *Self) void {
-    self.timestamp = Timestamp.now();
+    self.timestamp = LogTime.now();
     self.log_buffer.reset();
 }
 
@@ -334,16 +334,34 @@ test "json appender - smoke test" {
     };
     var mtx: std.Thread.Mutex = .{};
 
-    var json_appender_extra1 = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender_extra1 = try JsonAppender.init(
+        allocator,
+        appender_output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender_extra1.deinit();
     _ = try json_appender_extra1.log_buffer.write("ABCXYZ");
 
-    var json_appender_extra2 = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender_extra2 = try JsonAppender.init(
+        allocator,
+        appender_output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender_extra2.deinit();
     json_appender_extra2.str("embedded_string_key", "embedded_string");
     json_appender_extra2.int("embedded_int_key", 1234);
 
-    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(
+        allocator,
+        appender_output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender.deinit();
     json_appender.msg("Checking various values");
     json_appender.trace("12345-1234");
@@ -373,7 +391,13 @@ test "json appender - binary" {
     };
     var mtx: std.Thread.Mutex = .{};
 
-    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(
+        allocator,
+        appender_output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender.deinit();
 
     const unencoded = [_]u8{ 'b', 'i', 'n', 'a', 'r', 'y' };
@@ -406,7 +430,13 @@ test "json appender - int" {
     };
     var mtx: std.Thread.Mutex = .{};
 
-    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(
+        allocator,
+        appender_output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender.deinit();
 
     json_appender.int("key", 0);
@@ -435,7 +465,13 @@ test "json appender - intx" {
     };
     var mtx: std.Thread.Mutex = .{};
 
-    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(
+        allocator,
+        appender_output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender.deinit();
 
     json_appender.intx("key", 0);
@@ -458,7 +494,13 @@ test "json appender - boolean" {
     };
     var mtx: std.Thread.Mutex = .{};
 
-    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(
+        allocator,
+        appender_output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender.deinit();
 
     json_appender.boolean("cats", true);
@@ -481,7 +523,7 @@ test "json appender - float" {
     };
     var mtx: std.Thread.Mutex = .{};
 
-    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, LogTime.now());
     defer json_appender.deinit();
 
     json_appender.float("key", 0);
@@ -510,7 +552,7 @@ test "json appender - error" {
     };
     var mtx: std.Thread.Mutex = .{};
 
-    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, LogTime.now());
     defer json_appender.deinit();
 
     json_appender.errK("errK", error.OutOfMemory);
@@ -530,7 +572,13 @@ test "json appender - ctx" {
     };
     var mtx: std.Thread.Mutex = .{};
 
-    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(
+        allocator,
+        appender_output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender.deinit();
 
     json_appender.ctx("some context");
@@ -547,7 +595,13 @@ test "json appender - src" {
     };
     var mtx: std.Thread.Mutex = .{};
 
-    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(
+        allocator,
+        appender_output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender.deinit();
 
     const local_src = @src();
@@ -564,7 +618,13 @@ test "json appender - obj" {
         .writer = &werr,
     };
     var mtx: std.Thread.Mutex = .{};
-    var json_appender = try JsonAppender.init(allocator, appender_output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(
+        allocator,
+        appender_output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender.deinit();
 
     const rats = .{ .some = "some", .thing = "thing" };
@@ -603,7 +663,7 @@ fn expectLogPostfixFmt(json_appender: *JsonAppender, comptime format: []const u8
 }
 
 fn extractPostfix(text: []const u8) []const u8 {
-    const ts_len = 30;
+    const ts_len = 30 - 3;
     const level_len = @tagName(default_logging_level).len;
     const prefix_len = 1 + (4 + 3 + ts_len + 1) + 1 + (4 + 4 + level_len + 1) + 1;
     if (text.len <= prefix_len) {

--- a/src/LogOptions.zig
+++ b/src/LogOptions.zig
@@ -1,0 +1,27 @@
+//! hissylogz logging options.
+
+const std = @import("std");
+
+const constants = @import("constants.zig");
+const LogFormat = constants.LogFormat;
+const LogOutput = constants.LogOutput;
+const LogLevel = constants.LogLevel;
+
+const Self = @This();
+
+level: LogLevel = .info,
+
+format: LogFormat = .json,
+
+output: LogOutput,
+
+ns_ts_supplier: *const fn () i128 = std.time.nanoTimestamp,
+
+// ---
+// hissylogz.
+//
+// Copyright 2024 Kevin Poalses.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/LogTime.zig
+++ b/src/LogTime.zig
@@ -1,0 +1,36 @@
+//! hissylogz - Logging timestamp
+
+const std = @import("std");
+const testing = std.testing;
+
+/// Timestamp
+const datetime = @import("datetime");
+const UtcTimestamp = datetime.datetime.Advanced(datetime.Date, datetime.time.Micro, false);
+
+const Self = @This();
+
+utc_ts: UtcTimestamp,
+
+/// Creates a log time (UTC timestamp) using the given number of nanoseconds since or before (negative) UNIX epoch.
+///
+/// UNIX epoch is: 1971-01-01T00:00:00Z
+pub fn init(epoch_nanos: i128) Self {
+    const days = @divFloor(epoch_nanos, std.time.ns_per_day);
+    const new_date = UtcTimestamp.Date.fromEpoch(@intCast(days));
+    const day_nanos = std.math.comptimeMod(epoch_nanos, std.time.ns_per_day);
+    // fromDaySeconds() is a misnomer, it takes subseconds, in this case, microseconds
+    const new_time = UtcTimestamp.Time.fromDaySeconds(@intCast(@divFloor(day_nanos, std.time.ns_per_us)));
+    const utc_ts: UtcTimestamp = .{
+        .date = new_date,
+        .time = new_time,
+    };
+    return .{ .utc_ts = utc_ts };
+}
+
+pub inline fn now() Self {
+    return init(std.time.nanoTimestamp());
+}
+
+pub fn format(self: Self, comptime _: []const u8, options: std.fmt.FormatOptions, writer: anytype) (@TypeOf(writer).Error || error{Range})!void {
+    try self.utc_ts.format("rfc3339", options, writer);
+}

--- a/src/Logger.zig
+++ b/src/Logger.zig
@@ -18,7 +18,7 @@ pub const LogLevel = constants.LogLevel;
 pub const LogOutput = constants.LogOutput;
 pub const LogFormat = constants.LogFormat;
 pub const LogOptions = constants.LogOptions;
-pub const Timestamp = constants.Timestamp;
+pub const LogTime = @import("LogTime.zig");
 pub const Ulid = @import("ulid.zig").Ulid;
 
 const std_logger = std.log.scoped(.hissylogz_logger);
@@ -157,13 +157,13 @@ fn createLogEntry(self: *Self, level: LogLevel) AllocationError!LogEntry {
     return switch (self.format) {
         .json => {
             return LogEntry.init(.{ .json = .{
-                .json_appender = try JsonAppender.init(self.allocator, self.output, self.output_mutex, level, Timestamp.now()),
+                .json_appender = try JsonAppender.init(self.allocator, self.output, self.output_mutex, level, LogTime.now()),
                 .logger = self,
             } });
         },
         .text => {
             return LogEntry.init(.{ .text = .{
-                .text_appender = try TextAppender.init(self.allocator, self.output, self.output_mutex, level, Timestamp.now()),
+                .text_appender = try TextAppender.init(self.allocator, self.output, self.output_mutex, level, LogTime.now()),
                 .logger = self,
             } });
         },

--- a/src/Logger.zig
+++ b/src/Logger.zig
@@ -88,33 +88,27 @@ pub fn deinit(self: *Self) void {
 }
 
 pub inline fn fine(self: *Self) *LogEntry {
-    var le = acquireEntry(self, .fine) catch return &noop_log_entry;
-    return le.name(self.name);
+    return acquireEntry(self, .fine) catch return &noop_log_entry;
 }
 
 pub inline fn debug(self: *Self) *LogEntry {
-    var le = acquireEntry(self, .debug) catch return &noop_log_entry;
-    return le.name(self.name);
+    return acquireEntry(self, .debug) catch return &noop_log_entry;
 }
 
 pub inline fn info(self: *Self) *LogEntry {
-    var le = acquireEntry(self, .info) catch return &noop_log_entry;
-    return le.name(self.name);
+    return acquireEntry(self, .info) catch return &noop_log_entry;
 }
 
 pub inline fn warn(self: *Self) *LogEntry {
-    var le = acquireEntry(self, .warn) catch return &noop_log_entry;
-    return le.name(self.name);
+    return acquireEntry(self, .warn) catch return &noop_log_entry;
 }
 
 pub inline fn err(self: *Self) *LogEntry {
-    var le = acquireEntry(self, .err) catch return &noop_log_entry;
-    return le.name(self.name);
+    return acquireEntry(self, .err) catch return &noop_log_entry;
 }
 
 pub inline fn fatal(self: *Self) *LogEntry {
-    var le = acquireEntry(self, .fatal) catch return &noop_log_entry;
-    return le.name(self.name);
+    return acquireEntry(self, .fatal) catch return &noop_log_entry;
 }
 
 fn acquireEntry(self: *Self, level: LogLevel) AllocationError!*LogEntry {
@@ -158,13 +152,27 @@ fn createLogEntry(self: *Self, level: LogLevel) AllocationError!LogEntry {
     return switch (self.format) {
         .json => {
             return LogEntry.init(.{ .json = .{
-                .json_appender = try JsonAppender.init(self.allocator, self.output, self.output_mutex, level, LogTime.init(self.ns_ts_supplier())),
+                .json_appender = try JsonAppender.init(
+                    self.allocator,
+                    self.name,
+                    self.output,
+                    self.output_mutex,
+                    level,
+                    LogTime.init(self.ns_ts_supplier()),
+                ),
                 .logger = self,
             } });
         },
         .text => {
             return LogEntry.init(.{ .text = .{
-                .text_appender = try TextAppender.init(self.allocator, self.output, self.output_mutex, level, LogTime.init(self.ns_ts_supplier())),
+                .text_appender = try TextAppender.init(
+                    self.allocator,
+                    self.name,
+                    self.output,
+                    self.output_mutex,
+                    level,
+                    LogTime.init(self.ns_ts_supplier()),
+                ),
                 .logger = self,
             } });
         },

--- a/src/Logger.zig
+++ b/src/Logger.zig
@@ -27,8 +27,7 @@ const Self = @This();
 
 const LogEntryPool = std.ArrayList(*LogEntry);
 
-const num_log_levels = 6;
-// const num_log_levels = @typeInfo(LogLevel).@"enum".fields.len; // FIXME - Something along these lines
+const num_log_levels = constants.num_log_levels;
 
 name: []const u8,
 allocator: std.mem.Allocator,
@@ -38,6 +37,7 @@ output: LogOutput,
 output_mutex: *std.Thread.Mutex,
 format: LogFormat,
 level: LogLevel,
+ns_ts_supplier: *const fn () i128,
 level_filter_ordinal: u3,
 
 pub fn init(name: []const u8, allocator: std.mem.Allocator, options: LogOptions, output_mutex: *std.Thread.Mutex) AllocationError!Self {
@@ -66,6 +66,7 @@ pub fn init(name: []const u8, allocator: std.mem.Allocator, options: LogOptions,
         .level = options.level,
         .output_mutex = output_mutex,
         .format = options.format,
+        .ns_ts_supplier = options.ns_ts_supplier,
         .level_filter_ordinal = level_filter_ordinal,
     };
 }
@@ -138,7 +139,7 @@ fn acquireEntry(self: *Self, level: LogLevel) AllocationError!*LogEntry {
         return new_entry;
     };
 
-    entry.reset();
+    entry.reset(LogTime.init(self.ns_ts_supplier()));
     return entry;
 }
 
@@ -157,13 +158,13 @@ fn createLogEntry(self: *Self, level: LogLevel) AllocationError!LogEntry {
     return switch (self.format) {
         .json => {
             return LogEntry.init(.{ .json = .{
-                .json_appender = try JsonAppender.init(self.allocator, self.output, self.output_mutex, level, LogTime.now()),
+                .json_appender = try JsonAppender.init(self.allocator, self.output, self.output_mutex, level, LogTime.init(self.ns_ts_supplier())),
                 .logger = self,
             } });
         },
         .text => {
             return LogEntry.init(.{ .text = .{
-                .text_appender = try TextAppender.init(self.allocator, self.output, self.output_mutex, level, LogTime.now()),
+                .text_appender = try TextAppender.init(self.allocator, self.output, self.output_mutex, level, LogTime.init(self.ns_ts_supplier())),
                 .logger = self,
             } });
         },
@@ -398,11 +399,11 @@ pub const LogEntry = struct {
         return self;
     }
 
-    inline fn reset(self: *LogEntry) void {
+    inline fn reset(self: *LogEntry, log_time: LogTime) void {
         switch (self.appender) {
             .noop => {},
-            .json => |*jctx| jctx.json_appender.reset(),
-            .text => |*tctx| tctx.text_appender.reset(),
+            .json => |*jctx| jctx.json_appender.reset(log_time),
+            .text => |*tctx| tctx.text_appender.reset(log_time),
         }
     }
 };
@@ -426,6 +427,7 @@ test "logger - smoke test" {
         .format = .json,
         .level = .debug,
         .output = output,
+        .ns_ts_supplier = std.time.nanoTimestamp,
     }, &mtx);
     defer json_logger.deinit();
 
@@ -435,6 +437,7 @@ test "logger - smoke test" {
         .format = .text,
         .level = .debug,
         .output = output,
+        .ns_ts_supplier = std.time.nanoTimestamp,
     }, &mtx);
     defer text_logger.deinit();
 

--- a/src/LoggerPool.zig
+++ b/src/LoggerPool.zig
@@ -26,10 +26,16 @@ rw_lock: std.Thread.RwLock,
 noop_logger: Logger,
 
 pub fn init(allocator: std.mem.Allocator, options: LogOptions) AllocationError!Self {
+    const noop_ts_supplier = struct {
+        fn supply() i128 {
+            return 0;
+        }
+    };
     const noop_options: LogOptions = .{
         .format = options.format,
         .level = .none,
         .output = options.output,
+        .ns_ts_supplier = noop_ts_supplier.supply,
     };
     const output_mutex = allocator.create(std.Thread.Mutex) catch return AllocationError.OutOfMemory;
     errdefer allocator.destroy(output_mutex);
@@ -125,6 +131,7 @@ test "logger pool - smoke test" {
         .format = .json,
         .level = .debug,
         .output = output,
+        .ns_ts_supplier = std.time.nanoTimestamp,
     };
 
     var logger_pool = try LoggerPool.init(allocator, log_options);

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -4,10 +4,6 @@ const std = @import("std");
 
 pub const hissylogz_version: std.SemanticVersion = .{ .major = 0, .minor = 0, .patch = 1 };
 
-/// Timestamp
-const datetime = @import("datetime");
-pub const Timestamp = datetime.datetime.Advanced(datetime.Date, datetime.time.Nano, false);
-
 /// Logging format
 pub const LogFormat = enum {
     json,

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -50,6 +50,7 @@ pub const LogOptions = struct {
     ns_ts_supplier: *const fn () i128,
 };
 
+
 // ---
 // hissylogz.
 //

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -40,12 +40,14 @@ pub const LogLevel = enum(u3) {
         return null;
     }
 };
+pub const num_log_levels = @typeInfo(LogLevel).Enum.fields.len - 1; // .none doesn't count
 
 /// Logging options
 pub const LogOptions = struct {
     level: LogLevel = .info,
     format: LogFormat = .json,
     output: LogOutput,
+    ns_ts_supplier: *const fn () i128,
 };
 
 // ---

--- a/src/hissylogz.zig
+++ b/src/hissylogz.zig
@@ -31,13 +31,19 @@ pub const Options = struct {
     filter_level: LogLevel = .info,
     log_format: LogFormat = .json,
     writer: *std.fs.File.Writer,
+    ns_ts_supplier: *const fn () i128 = std.time.nanoTimestamp,
 };
 
 pub fn loggerPool(allocator: std.mem.Allocator, options: Options) errors.AllocationError!LoggerPool {
     const output: constants.LogOutput = .{
         .writer = options.writer,
     };
-    const log_options: LogOptions = .{ .output = output, .format = options.log_format, .level = options.filter_level };
+    const log_options: LogOptions = .{
+        .output = output,
+        .format = options.log_format,
+        .level = options.filter_level,
+        .ns_ts_supplier = options.ns_ts_supplier,
+    };
     return try LoggerPool.init(allocator, log_options);
 }
 
@@ -142,6 +148,7 @@ test "hissylogz - dependencies trigger" {
         .format = .json,
         .level = .debug,
         .output = output,
+        .ns_ts_supplier = std.time.nanoTimestamp,
     };
 
     var logger = try Logger.init("logging", allocator, log_options, &mtx);

--- a/src/hissylogz.zig
+++ b/src/hissylogz.zig
@@ -125,6 +125,7 @@ test "hissylogz - dependencies trigger" {
     };
     var json_appender = try JsonAppender.init(
         allocator,
+        "json",
         output,
         &mtx,
         .debug,
@@ -136,6 +137,7 @@ test "hissylogz - dependencies trigger" {
 
     var text_appender = try JsonAppender.init(
         allocator,
+        "text",
         output,
         &mtx,
         .debug,

--- a/src/hissylogz.zig
+++ b/src/hissylogz.zig
@@ -13,6 +13,7 @@ pub const LogLevel = constants.LogLevel;
 pub const LogFormat = constants.LogFormat;
 pub const LogOutput = constants.LogOutput;
 pub const LogOptions = constants.LogOptions;
+pub const LogTime = @import("LogTime.zig");
 
 pub const Logger = @import("Logger.zig");
 pub const LoggerPool = @import("LoggerPool.zig");
@@ -116,12 +117,24 @@ test "hissylogz - dependencies trigger" {
     const output: LogOutput = .{
         .writer = &w,
     };
-    var json_appender = try JsonAppender.init(allocator, output, &mtx, .debug, constants.Timestamp.now());
+    var json_appender = try JsonAppender.init(
+        allocator,
+        output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer json_appender.deinit();
 
     std.debug.print("\ttext appender\n", .{});
 
-    var text_appender = try TextAppender.init(allocator, output, &mtx, .debug, constants.Timestamp.now());
+    var text_appender = try JsonAppender.init(
+        allocator,
+        output,
+        &mtx,
+        .debug,
+        LogTime.now(),
+    );
     defer text_appender.deinit();
 
     std.debug.print("\tlogger\n", .{});


### PR DESCRIPTION
feat: Appenders now have log name and thread id as part of header. 
reno: Timestamp logging precision now in microseconds
feat: Timestamp source now overridable by user